### PR TITLE
Support X-Forwarded-Host

### DIFF
--- a/lib/federationServerService.js
+++ b/lib/federationServerService.js
@@ -1,26 +1,17 @@
+var utils = require('./utils');
 var templates = require('./templates');
 var URL_PATH = '/wsfed/adfs/fs/federationserverservice.asmx';
 var encoders = require('./encoders');
 
 function getLocation (req) {
-  var protocol = req.headers['x-iisnode-https'] && req.headers['x-iisnode-https'] == 'ON' ? 
-                 'https' : 
-                 (req.headers['x-forwarded-proto'] || req.protocol);
-  
-  return protocol + '://' + req.headers['host'] + req.originalUrl;
+  return utils.getBaseUrl(req) + req.originalUrl;
 }
 
 function getEndpointAddress (req, endpointPath) {
-  endpointPath = endpointPath || 
+  endpointPath = endpointPath ||
     (req.originalUrl.substr(0, req.originalUrl.length - URL_PATH.length));
-
-  var protocol = req.headers['x-iisnode-https'] && req.headers['x-iisnode-https'] == 'ON' ? 
-                 'https' : 
-                 (req.headers['x-forwarded-proto'] || req.protocol);
-  
-  return protocol + '://' + req.headers['host'] + endpointPath;
+  return utils.getBaseUrl(req) + endpointPath;
 }
-
 
 module.exports.wsdl = function (req, res) {
   res.set('Content-Type', 'text/xml; charset=UTF-8');

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,35 +1,32 @@
+var utils = require('./utils');
 var templates = require('./templates');
 var PassportProfileMapper = require('./claims/PassportProfileMapper');
 var URL_PATH = '/FederationMetadata/2007-06/FederationMetadata.xml';
 var encoders = require('./encoders');
 
 function getEndpointAddress (req, endpointPath) {
-  endpointPath = endpointPath || 
+  endpointPath = endpointPath ||
     (req.originalUrl.substr(0, req.originalUrl.length - URL_PATH.length));
 
-  var protocol = req.headers['x-iisnode-https'] && req.headers['x-iisnode-https'] == 'on' ? 
-                 'https' : 
-                 (req.headers['x-forwarded-proto'] || req.protocol);
-  
-  return protocol + '://' + req.headers['host'] + endpointPath;
+  return utils.getBaseUrl(req) + endpointPath;
 }
 
 /**
  * WSFederation metadata endpoint
  *
  * This endpoint returns a wsfederation metadata document.
- * 
+ *
  * You should expose this endpoint in an address like:
  *
  * 'https://your-wsfederation-server.com/FederationMetadata/2007-06/FederationMetadata.xml
- * 
+ *
  * options:
  * - issuer string
  * - cert the public certificate
  * - profileMapper a function that given a user returns a claim based identity, also contains the metadata. By default maps from Passport.js user schema (PassportProfile).
  * - endpointPath optional, defaults to the root of the fed metadata document.
  * - mexEndpoint optional, url of the wsfederation MEX endpoint metadata document.
- * 
+ *
  * @param  {[type]} options [description]
  * @return {[type]}         [description]
  */
@@ -48,7 +45,7 @@ function metadataMiddleware (options) {
   var claimTypes = (options.profileMapper || PassportProfileMapper).prototype.metadata;
   var issuer = options.issuer;
   var pem = encoders.removeHeaders(options.cert);
-  
+
   return function (req, res) {
     var endpoint = getEndpointAddress(req, options.endpointPath);
     var mexEndpoint = options.mexEndpoint ? getEndpointAddress(req, options.mexEndpoint) : '';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,11 @@ exports.escape = function(html) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 };
+
+exports.getBaseUrl = function(req) {
+  var protocol = req.headers['x-iisnode-https'] && req.headers['x-iisnode-https'] === 'on' ?
+                 'https' :
+                 (req.headers['x-forwarded-proto'] || req.protocol);
+  var host = req.headers['x-forwarded-host'] || req.headers['host'];
+  return protocol + '://' + host;
+};

--- a/test/metadata.tests.js
+++ b/test/metadata.tests.js
@@ -15,7 +15,7 @@ describe('wsfed metadata', function () {
   before(function (done) {
     server.start(done);
   });
-  
+
   after(function (done) {
     server.close(done);
   });
@@ -24,7 +24,7 @@ describe('wsfed metadata', function () {
     var doc, content;
     before(function (done) {
       request.get({
-        jar: request.jar(), 
+        jar: request.jar(),
         uri: 'http://localhost:5050/wsfed/FederationMetadata/2007-06/FederationMetadata.xml'
       }, function (err, response, b){
         if(err) return done(err);
@@ -59,5 +59,28 @@ describe('wsfed metadata', function () {
         .to.not.contain('\n');
     });
 
+  });
+
+  describe('request to metadata with proxy', function (){
+    var doc, content;
+    before(function (done) {
+      request.get({
+        jar: request.jar(),
+        uri: 'http://localhost:5050/wsfed/FederationMetadata/2007-06/FederationMetadata.xml',
+        headers: {
+          'X-Forwarded-Host': 'myserver.com'
+        }
+      }, function (err, response, b){
+        if(err) return done(err);
+        content = b;
+        doc = new xmldom.DOMParser().parseFromString(b).documentElement;
+        done();
+      });
+    });
+
+    it('should have the custom endpoint url', function(){
+      expect(doc.getElementsByTagName('EndpointReference')[0].firstChild.textContent)
+        .to.equal('http://myserver.com/wsfed');
+    });
   });
 });


### PR DESCRIPTION
If the application is hosted behind a reverse proxy, allow the reverse proxy to pass the original host used by the client and use this as the base url.