### PR TITLE
Allow custom response handler.

### DIFF
--- a/lib/wsfed.js
+++ b/lib/wsfed.js
@@ -57,6 +57,8 @@ module.exports = function(options) {
     res.send(form(model));
   }
 
+  var responseHandler = options.responseHandler || renderResponse;
+
   function execute (postUrl, req, res, next) {
     var audience =  options.audience ||
                     req.query.wtrealm ||
@@ -94,7 +96,7 @@ module.exports = function(options) {
         var escapedWctx = utils.escape(ctx); 
         assertion = '<t:RequestSecurityTokenResponse Context="'+ escapedWctx + '" xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust"><t:RequestedSecurityToken>' + assertion + '</t:RequestedSecurityToken></t:RequestSecurityTokenResponse>';
 
-        return renderResponse(res, postUrl, ctx, assertion);
+        return responseHandler(res, postUrl, ctx, assertion);
       });
 
     } else {
@@ -105,7 +107,7 @@ module.exports = function(options) {
         algorithm:        options.jwtAlgorithm || 'RS256'
       });
 
-      return renderResponse(res, postUrl, ctx, signed);
+      return responseHandler(res, postUrl, ctx, signed);
     }
   }
 


### PR DESCRIPTION
Uses the same `options.responseHandler` pattern used by `node-samlp`.