### PR TITLE
Allow extra claims to be inserted into a JWT response.

### DIFF
--- a/lib/wsfed.js
+++ b/lib/wsfed.js
@@ -4,6 +4,7 @@ var utils                 = require('./utils');
 var saml11 = require('saml').Saml11;
 var jwt                   = require('jsonwebtoken');
 var interpolate           = require('./interpolate');
+var xtend                 = require('xtend');
 
 function asResource(res) {
   if(res.substr(0, 6) !== 'http:/' &&
@@ -100,6 +101,10 @@ module.exports = function(options) {
       });
 
     } else {
+      if (options.extendJWT && typeof options.extendJWT === 'object') {
+        user = xtend(user, options.extendJWT);
+      }
+
       var signed = jwt.sign(user, options.key.toString(), {
         expiresInMinutes: (options.lifetime || options.lifetimeInSeconds || (60 * 60 * 8)) / 60,
         audience:         audience,

--- a/test/jwt.tests.js
+++ b/test/jwt.tests.js
@@ -15,32 +15,31 @@ var credentials = {
 
 
 describe('wsfed+jwt', function () {
-  before(function (done) {
-    server.start({
-      jwt: true
-    }, done);
-  });
-  
-  after(function (done) {
-    server.close(done);
-  });
 
   describe('authorizing', function () {
     var body, $, signedAssertion, profile;
 
+    after(function (done) {
+      server.close(done);
+    });
+
     before(function (done) {
-      request.get({
-        jar: request.jar(), 
-        uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
-      }, function (err, response, b){
-        if(err) return done(err);
-        body = b;
-        $ = cheerio.load(body);
-        var signedAssertion = $('input[name="wresult"]').attr('value');
-        jwt.verify(signedAssertion, credentials.cert.toString(), function (err, decoded) {
-          if (err) return done(err);
-          profile = decoded;
-          done();
+      server.start({
+        jwt: true
+      }, function(err) {
+        request.get({
+          jar: request.jar(),
+          uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
+        }, function (err, response, b){
+          if(err) return done(err);
+          body = b;
+          $ = cheerio.load(body);
+          var signedAssertion = $('input[name="wresult"]').attr('value');
+          jwt.verify(signedAssertion, credentials.cert.toString(), function (err, decoded) {
+            if (err) return done(err);
+            profile = decoded;
+            done();
+          });
         });
       });
     });
@@ -48,6 +47,51 @@ describe('wsfed+jwt', function () {
     it('should have the attributes', function(){
       expect(profile).to.have.property('displayName');
       expect(profile.id).to.equal('12334444444');
+    });
+
+    it('should have jwt attributes', function(){
+      expect(profile).to.have.property('aud');
+      expect(profile).to.have.property('iss');
+      expect(profile).to.have.property('iat');
+    });
+
+  });
+
+  describe('authorizing with extra claims', function () {
+    var body, $, signedAssertion, profile;
+
+    after(function (done) {
+      server.close(done);
+    });
+
+    before(function (done) {
+      server.start({
+        jwt: true,
+        extendJWT: { extra: 'claim' }
+      }, function(err) {
+        request.get({
+          jar: request.jar(),
+          uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
+        }, function (err, response, b){
+          if(err) return done(err);
+          body = b;
+          $ = cheerio.load(body);
+          var signedAssertion = $('input[name="wresult"]').attr('value');
+          jwt.verify(signedAssertion, credentials.cert.toString(), function (err, decoded) {
+            if (err) return done(err);
+            profile = decoded;
+            console.log(decoded);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should have the attributes', function(){
+      expect(profile).to.have.property('displayName');
+      expect(profile.id).to.equal('12334444444');
+      expect(profile).to.have.property('extra');
+      expect(profile.extra).to.equal('claim');
     });
 
     it('should have jwt attributes', function(){


### PR DESCRIPTION
Useful for binding the issued token to, e.g., the session.