### PR TITLE
fix vulnerabilities reported by npm/snyk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 npm-debug.log
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 8
   - 10
   - 12

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "auth"
   ],
   "author": "Auth0",
-  "license": "mit",
+  "license": "MIT",
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
     "ejs": "2.5.5",
@@ -29,7 +29,6 @@
     "@commitlint/config-conventional": "^11.0.0",
     "chai": "~1.5.0",
     "cheerio": "0.22.0",
-    "debug": "~3.2.6",
     "express": "~4.17.1",
     "husky": "^4.3.0",
     "mocha": "~8.2.0",
@@ -37,7 +36,7 @@
     "standard-version": "^9.0.0",
     "xml-crypto": "~0.10.1",
     "xml-encryption": "1.2.1",
-    "xmldom": "=0.1.15",
+    "xmldom": "~0.1.17",
     "xpath": "0.0.5",
     "xtend": "~2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -22,21 +22,21 @@
     "@auth0/thumbprint": "0.0.6",
     "ejs": "2.5.5",
     "jsonwebtoken": "~5.0.4",
-    "saml": "^0.12.1"
+    "saml": "^1.0.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^9.1.2",
-    "@commitlint/config-conventional": "^9.1.2",
+    "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
     "chai": "~1.5.0",
     "cheerio": "0.22.0",
     "debug": "~3.2.6",
-    "express": "~3.1.0",
+    "express": "~4.17.1",
     "husky": "^4.3.0",
-    "mocha": "~1.8.1",
-    "request": "~2.14.0",
+    "mocha": "~8.2.0",
+    "request": "~2.88.2",
     "standard-version": "^9.0.0",
     "xml-crypto": "~0.10.1",
-    "xml-encryption": "0.11.0",
+    "xml-encryption": "1.2.1",
     "xmldom": "=0.1.15",
     "xpath": "0.0.5",
     "xtend": "~2.0.3"

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -37,11 +37,9 @@ module.exports.start = function(options, callback){
 
   var app = express();
 
-  app.configure(function(){
-    this.use(function(req,res,next){
-      req.user = fakeUser;
-      next();
-    });
+  app.use(function(req,res,next){
+    req.user = fakeUser;
+    next();
   });
 
   app.get('/wsfed/FederationMetadata/2007-06/FederationMetadata.xml',
@@ -75,7 +73,7 @@ module.exports.start = function(options, callback){
       key:                credentials.key
     }, module.exports.options))(req, res, function(err){
       if (err) {
-        return res.send(400, err.message);
+        return res.status(400).send(err.message);
       }
       next();
     })


### PR DESCRIPTION
This PR fixes all vulnerabilities reported by `npm audit` and `snyk test`

```
 === npm audit security report ===

# Run  npm install --save-dev express@4.17.1  to resolve 17 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ methodOverride Middleware Reflected Cross-Site Scripting     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ connect                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/3                               │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ No Charset in Content-Type Header                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ express                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/8                               │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Denial-of-Service Extended Event Loop Blocking               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ qs                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > qs                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/28                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Denial-of-Service Memory Exhaustion                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ qs                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > qs                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/29                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Directory Traversal                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > send                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/32                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Directory Traversal                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/32                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Root Path Disclosure                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > send                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/56                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Root Path Disclosure                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/56                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Timing Attack                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ cookie-signature                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > cookie-signature                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/134                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Timing Attack                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ cookie-signature                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > cookie-signature                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/134                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > fresh                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/526                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > send > fresh                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/526                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send > fresh                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/526                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > fresh                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/526                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mime                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > send > mime                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/535                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mime                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send > mime                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/535                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution Protection Bypass                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ qs                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > qs                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1469                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm install --save-dev mocha@8.2.0  to resolve 2 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ms                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mocha [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mocha > ms                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/46                              │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ growl                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mocha [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mocha > growl                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/146                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm install saml@0.15.0  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ moment                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ saml                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ saml > moment                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/532                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm install --save-dev @commitlint/config-conventional@11.0.0  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ dot-prop                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @commitlint/config-conventional [dev]                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @commitlint/config-conventional >                            │
│               │ conventional-changelog-conventionalcommits > compare-func >  │
│               │ dot-prop                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1213                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm install --save-dev xml-encryption@1.2.1  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution in node-forge                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ node-forge                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ xml-encryption [dev]                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ xml-encryption > node-forge                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1561                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Remote Memory Exposure                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ request                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.68.0                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ request [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ request                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/309                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mime                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >= 1.4.1 < 2.0.0 || >= 2.0.3                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ request [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ request > form-data > mime                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/535                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mime                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >= 1.4.1 < 2.0.0 || >= 2.0.3                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ request [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ request > mime                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/535                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution in node-forge                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ node-forge                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >= 0.10.0                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ saml                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ saml > xml-encryption > node-forge                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1561                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ ms (Tiny ms conversion utility) Version String Handling      │
│               │ Remote DoS                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ms                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ 0.7.1                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mocha [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mocha > ms                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.org/package/ms,https://nodesecurity.io/adviso… │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ The ms package before 0.7.1 for Node.js allows attackers to  │
│               │ cause a denial of service (CPU consumption) via a long       │
│               │ version string, aka a "regular expression denial of service  │
│               │ (ReDoS)."                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ms                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ 0.7.1                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mocha [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mocha > ms                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ http://www.openwall.com/lists/oss-security/2016/04/20/11,ht… │
└───────────────┴──────────────────────────────────────────────────────────────┘
# Run  npm install --save-dev express@3.11  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ The Express web framework before 3.11 and 4.x before 4.5 for │
│               │ Node.js does not provide a charset field in HTTP             │
│               │ Content-Type headers in 400 level responses, which might     │
│               │ allow remote attackers to conduct cross-site scripting (XSS) │
│               │ attacks via characters in a non-standard encoding.           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ express                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://bugzilla.redhat.com/show_bug.cgi?id=1203190,https:/… │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ The send package before 0.11.1 for Node.js allows attackers  │
│               │ to obtain the root path via unspecified vectors.             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │                                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ http://www.openwall.com/lists/oss-security/2016/04/20/11,ht… │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ visionmedia send before 0.8.4 for Node.js uses a partial     │
│               │ comparison for verifying whether a directory is within the   │
│               │ document root, which allows remote attackers to access       │
│               │ restricted directories, as demonstrated using                │
│               │ "public-restricted" under a "public" directory.              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ send                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ 0.8.4                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > send                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ http://lists.apple.com/archives/security-announce/2015/Sep/… │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ connect node module before 2.14.0 suffers from a Cross-Site  │
│               │ Scripting (XSS) vulnerability due to a lack of validation of │
│               │ file in directory.js middleware.                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ connect                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ 2.14.0                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/senchalabs/connect/commit/6d5dd30075d2bc… │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Node-cookie-signature before 1.0.6 is affected by a timing   │
│               │ attack due to the type of comparison used.                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ cookie-signature                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ 1.0.6                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ express [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ express > connect > cookie-signature                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=838618,ht… │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 33 vulnerabilities (8 low, 12 moderate, 12 high, 1 critical) in 415 scanned packages
  run `npm audit fix` to fix 2 of them.
  21 vulnerabilities require semver-major dependency updates.
  10 vulnerabilities require manual review. See the full report for details.
```

Also, it removes node v4, v6 and v8 in Travis configuration.