### PR TITLE
feat: Adding support for `nameIdentifierFormat` option to override default Format attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 npm-debug.log
 package-lock.json
+.idea

--- a/lib/wsfed.js
+++ b/lib/wsfed.js
@@ -93,7 +93,7 @@ module.exports = function(options) {
         audiences:            audience,
         attributes:           claims,
         nameIdentifier:       ni.nameIdentifier,
-        nameIdentifierFormat: ni.nameIdentifierFormat,
+        nameIdentifierFormat: options.nameIdentifierFormat,
         encryptionPublicKey:  options.encryptionPublicKey,
         encryptionCert:       options.encryptionCert
       }, function(err, assertion) {

--- a/lib/wsfed.js
+++ b/lib/wsfed.js
@@ -93,7 +93,7 @@ module.exports = function(options) {
         audiences:            audience,
         attributes:           claims,
         nameIdentifier:       ni.nameIdentifier,
-        nameIdentifierFormat: options.nameIdentifierFormat,
+        nameIdentifierFormat: ni.nameIdentifierFormat || options.nameIdentifierFormat,
         encryptionPublicKey:  options.encryptionPublicKey,
         encryptionCert:       options.encryptionCert
       }, function(err, assertion) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@auth0/thumbprint": "0.0.6",
     "ejs": "2.5.5",
     "jsonwebtoken": "~5.0.4",
-    "saml": "^1.0.0"
+    "saml": "^1.0.0",
+    "xtend": "~2.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -37,8 +38,7 @@
     "xml-crypto": "~0.10.1",
     "xml-encryption": "1.2.1",
     "xmldom": "~0.1.17",
-    "xpath": "0.0.5",
-    "xtend": "~2.0.3"
+    "xpath": "0.0.5"
   },
   "husky": {
     "hooks": {

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -99,7 +99,7 @@ describe('wsfed', function () {
     });
   });
 
-  describe('when using a different name identifier format', function (){
+  describe('when a name identifier format is passed as an auth option', function (){
     var body, $, signedAssertion, attributes;
 
     const fakeNameIdentifierFomat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:swfedfakeformat';
@@ -120,7 +120,7 @@ describe('wsfed', function () {
       });
     });
 
-    it(`should set name identifier format to ${fakeNameIdentifierFomat}`, function (){
+    it(`should set name identifier format to the passed auth option`, function (){
       const nameIdentifier = xmlhelper.getNameIdentifier(signedAssertion);
       const formatAttributeValue = nameIdentifier.getAttribute('Format');
       expect(formatAttributeValue).to.equal(fakeNameIdentifierFomat);

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -138,7 +138,7 @@ describe('wsfed', function () {
         var $ = cheerio.load(body);
         var wresult = $('input[name="wresult"]').attr('value');
         var signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
-        
+
         expect(xmlhelper.getAudiences(signedAssertion)[0].textContent)
           .to.equal('urn:auth0:superclient');
 
@@ -207,6 +207,7 @@ describe('wsfed', function () {
     describe('when NameIdentifier and NameIdentifierFormat have been configured', function() {
       const fakeNameIdentifier = 'fakeNameIdentifier';
       const fakeNameIdentifierFormat = 'fakeNameIdentifierFormat';
+      var body, $, signedAssertion, attributes;
 
       function ProfileMapper(user) {
         this.user = user;
@@ -229,27 +230,28 @@ describe('wsfed', function () {
         };
       });
 
+      function createRequest(done) {
+        request.get({
+          jar: request.jar(),
+          uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
+        }, function (err, response, b) {
+          if (err) return done(err);
+          body = b;
+          $ = cheerio.load(body);
+          var wresult = $('input[name="wresult"]').attr('value');
+          signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
+          attributes = xmlhelper.getAttributes(signedAssertion);
+          done();
+        });
+      }
+
       describe('when nameIdentifierFormat option has been passed', function() {
 
         const fakeOptionNameIdentifierFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:swfedfakeformat';
-        var body, $, signedAssertion, attributes;
 
         before(function(done) {
-
           server.options.nameIdentifierFormat = fakeOptionNameIdentifierFormat;
-
-          request.get({
-            jar: request.jar(),
-            uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
-          }, function (err, response, b) {
-            if (err) return done(err);
-            body = b;
-            $ = cheerio.load(body);
-            var wresult = $('input[name="wresult"]').attr('value');
-            signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
-            attributes = xmlhelper.getAttributes(signedAssertion);
-            done();
-          });
+          createRequest(done);
         });
 
         it('should set name identifier', function() {
@@ -267,21 +269,8 @@ describe('wsfed', function () {
 
       describe('when nameIdentifierFormat option has NOT been passed', function() {
 
-        var body, $, signedAssertion, attributes;
-
         before(function(done) {
-          request.get({
-            jar: request.jar(),
-            uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:the-super-client-id'
-          }, function (err, response, b) {
-            if (err) return done(err);
-            body = b;
-            $ = cheerio.load(body);
-            var wresult = $('input[name="wresult"]').attr('value');
-            signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
-            attributes = xmlhelper.getAttributes(signedAssertion);
-            done();
-          });
+          createRequest(done);
         });
 
         it('should set name identifier', function() {

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -1,10 +1,10 @@
-var expect = require('chai').expect;
-var server = require('./fixture/server');
-var request = require('request');
-var cheerio = require('cheerio');
-var xmlhelper = require('./xmlhelper');
-var fs = require('fs');
-var path = require('path');
+const expect = require('chai').expect;
+const server = require('./fixture/server');
+const request = require('request');
+const cheerio = require('cheerio');
+const xmlhelper = require('./xmlhelper');
+const fs = require('fs');
+const path = require('path');
 
 describe('wsfed', function () {
   before(function (done) {
@@ -16,7 +16,7 @@ describe('wsfed', function () {
   });
 
   describe('authorizing', function () {
-    var body, $, signedAssertion, attributes;
+    let body, $, signedAssertion, attributes;
 
     before(function (done) {
       request.get({
@@ -26,7 +26,7 @@ describe('wsfed', function () {
         if(err) return done(err);
         body = b;
         $ = cheerio.load(body);
-        var wresult = $('input[name="wresult"]').attr('value');
+        let wresult = $('input[name="wresult"]').attr('value');
         signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
         attributes = xmlhelper.getAttributes(signedAssertion);
         done();
@@ -42,19 +42,19 @@ describe('wsfed', function () {
     });
 
     it('should contain a valid signal assertion', function(){
-      var isValid = xmlhelper.verifySignature(
+      const isValid = xmlhelper.verifySignature(
                 signedAssertion, 
                 server.credentials.cert);
       expect(isValid).to.be.ok;
     });
 
     it('should use sha256 as default signature algorithm', function(){
-      var algorithm = xmlhelper.getSignatureMethodAlgorithm(signedAssertion);
+      const algorithm = xmlhelper.getSignatureMethodAlgorithm(signedAssertion);
       expect(algorithm).to.equal('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256');
     });
 
     it('should use sha256 as default diigest algorithm', function(){
-      var algorithm = xmlhelper.getDigestMethodAlgorithm(signedAssertion);
+      const algorithm = xmlhelper.getDigestMethodAlgorithm(signedAssertion);
       expect(algorithm).to.equal('http://www.w3.org/2001/04/xmlenc#sha256');
     });
 
@@ -100,7 +100,7 @@ describe('wsfed', function () {
   });
 
   describe('when a name identifier format is passed as an auth option', function (){
-    var body, $, signedAssertion, attributes;
+    let body, $, signedAssertion, attributes;
 
     const fakeNameIdentifierFomat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:swfedfakeformat';
 
@@ -113,7 +113,7 @@ describe('wsfed', function () {
           if(err) return done(err);
           body = b;
           $ = cheerio.load(body);
-          var wresult = $('input[name="wresult"]').attr('value');
+          let wresult = $('input[name="wresult"]').attr('value');
           signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
           attributes = xmlhelper.getAttributes(signedAssertion);
           done();
@@ -134,10 +134,10 @@ describe('wsfed', function () {
         uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=123&wtrealm=urn:auth0:superclient'
       }, function (err, response, b){
         if(err) return done(err);
-        var body = b;
-        var $ = cheerio.load(body);
-        var wresult = $('input[name="wresult"]').attr('value');
-        var signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
+        const body = b;
+        const $ = cheerio.load(body);
+        const wresult = $('input[name="wresult"]').attr('value');
+        const signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
 
         expect(xmlhelper.getAudiences(signedAssertion)[0].textContent)
           .to.equal('urn:auth0:superclient');
@@ -149,16 +149,16 @@ describe('wsfed', function () {
 
   describe('when the wctx has ampersand(&)', function (){
     it('should return escaped Context value', function (done) {
-      var wctx = encodeURIComponent('rm=0&id=passive&ru=%2f');
+      const wctx = encodeURIComponent('rm=0&id=passive&ru=%2f');
 
       request.get({
         jar: request.jar(), 
         uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wctx=' + wctx + '&wtrealm=urn:auth0:superclient'
       }, function (err, response, b){
         if(err) return done(err);
-        var body = b;
-        var $ = cheerio.load(body);
-        var wresult = $('input[name="wresult"]').attr('value');
+        const body = b;
+        const $ = cheerio.load(body);
+        const wresult = $('input[name="wresult"]').attr('value');
 
         expect(wresult.indexOf(' Context="rm=0&amp;id=passive&amp;ru=%2f" '))
           .to.be.above(-1);
@@ -176,9 +176,9 @@ describe('wsfed', function () {
         uri: 'http://localhost:5050/wsfed?wa=wsignin1.0&wtrealm=urn:auth0:superclient'
       }, function (err, response, b){
         if(err) return done(err);
-        var body = b;
-        var $ = cheerio.load(body);
-        var wresult = $('input[name="wresult"]').attr('value');
+        const body = b;
+        const $ = cheerio.load(body);
+        const wresult = $('input[name="wresult"]').attr('value');
 
         expect(wresult.indexOf('http://foo?foo&amp;foo'))
           .to.be.above(-1);
@@ -207,7 +207,7 @@ describe('wsfed', function () {
     describe('when NameIdentifier and NameIdentifierFormat have been configured', function() {
       const fakeNameIdentifier = 'fakeNameIdentifier';
       const fakeNameIdentifierFormat = 'fakeNameIdentifierFormat';
-      var body, $, signedAssertion, attributes;
+      let body, $, signedAssertion, attributes;
 
       function ProfileMapper(user) {
         this.user = user;
@@ -238,7 +238,7 @@ describe('wsfed', function () {
           if (err) return done(err);
           body = b;
           $ = cheerio.load(body);
-          var wresult = $('input[name="wresult"]').attr('value');
+          let wresult = $('input[name="wresult"]').attr('value');
           signedAssertion = /<t:RequestedSecurityToken>(.*)<\/t:RequestedSecurityToken>/.exec(wresult)[1];
           attributes = xmlhelper.getAttributes(signedAssertion);
           done();

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -204,7 +204,7 @@ describe('wsfed', function () {
   });
 
   describe('using custom profile mapper', function() {
-    describe('when NameIdentifier and NameIdentifierFormat have been configured', function() {
+    describe('when NameIdentifier and NameIdentifierFormat have been configured in the profile mapper', function() {
       const fakeNameIdentifier = 'fakeNameIdentifier';
       const fakeNameIdentifierFormat = 'fakeNameIdentifierFormat';
       let body, $, signedAssertion, attributes;
@@ -245,7 +245,7 @@ describe('wsfed', function () {
         });
       }
 
-      describe('when nameIdentifierFormat option has been passed', function() {
+      describe('when a name identifier format is passed as an auth option', function() {
 
         const fakeOptionNameIdentifierFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:swfedfakeformat';
 
@@ -267,7 +267,7 @@ describe('wsfed', function () {
 
       });
 
-      describe('when nameIdentifierFormat option has NOT been passed', function() {
+      describe('when a name identifier format is NOT passed as an auth option', function() {
 
         before(function(done) {
           createRequest(done);

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -120,7 +120,7 @@ describe('wsfed', function () {
       });
     });
 
-    it(`should set name identifier format to the passed auth option`, function (){
+    it('should set name identifier format to the passed auth option', function (){
       const nameIdentifier = xmlhelper.getNameIdentifier(signedAssertion);
       const formatAttributeValue = nameIdentifier.getAttribute('Format');
       expect(formatAttributeValue).to.equal(fakeNameIdentifierFomat);

--- a/test/wsfed.tests.js
+++ b/test/wsfed.tests.js
@@ -204,7 +204,7 @@ describe('wsfed', function () {
   });
 
   describe('using custom profile mapper', function() {
-    describe('when NameIdentifier is found', function() {
+    describe('when NameIdentifier and NameIdentifierFormat have been configured', function() {
       const fakeNameIdentifier = 'fakeNameIdentifier';
       const fakeNameIdentifierFormat = 'fakeNameIdentifierFormat';
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Currently we do not expose an option when calling `wsfed.auth` where a user can pass an option for `nameIdentifierFormat` and have it behave as the default if there is no custom profile mapper configured that returns a `nameIdentifierFormat` value. This PR aims to add this functionality.

#### Example usage
```javascript
wsfed.auth({
   nameIdentifierFormat: 'my-awesome-format'
});
```
#### SAML assertion example
```xml
....
      <saml:AttributeStatement>
        <saml:Subject>
          <saml:NameIdentifier Format="my-awesome-format">some-identifier</saml:NameIdentifier>
          <saml:SubjectConfirmation>
....
```
> Note:  this is the same behaviour we have in the [node-samlp](https://github.com/auth0/node-samlp/tree/6cec7bde238f2481761b763891160072f13d036c) library.

### Changes
 - Support  name identifier format option.
 - Moving `xtend` library into production dependency.
 - Adding `.idea` to .gitignore.

### Testing

This new feature can be tested by passing an `nameIdentifierFormat` option to the `wsfed.auth` method, and when constructing the SAML assertion you should see the value be reflected in the `Format`. It should:
- Override the default `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified` 
- Be overridden by a custom profile mapper if it returns a `nameIdentifierFormat` property.
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
