### PR TITLE
Fix getPostURL in example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ app.get('/wsfed', wsfed.auth({
   issuer:     'the-issuer',
   cert:       fs.readFileSync(path.join(__dirname, 'some-cert.pem')),
   key:        fs.readFileSync(path.join(__dirname, 'some-cert.key')),
-  getPostUrl: function (wtrealm, wreply, req, callback) {
+  getPostURL: function (wtrealm, wreply, req, callback) {
                 return cb( null, 'http://someurl.com')
               }
 }));


### PR DESCRIPTION
URL supposed to be uppercase.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I created a simple Hello World ExpressJS app, added wsfed-node package and copied the example code from the README.
But I got:

```
Error: getPostURL is required
```

I found that the 'url' in getPostUrl should be uppercase. This PR fixes that the README.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
