### PR TITLE
fix: update ejs to 3.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
-    "ejs": "2.5.5",
+    "ejs": "^3.1.10",
     "jsonwebtoken": "^9.0.0",
     "saml": "^1.0.0",
     "xtend": "~2.0.3"


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Bumping ejs dependency as per https://snyk.io/vuln/SNYK-JS-EJS-2803307

this only affects the templates in wsfed. There is testing around these templates and they still all pass via `npm run test`


### References
https://snyk.io/vuln/SNYK-JS-EJS-2803307

### Testing

- [N/A] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [N/A] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [✅ ] All active GitHub checks for tests, formatting, and security are passing
- [✅ ] The correct base branch is being used, if not the default branch
