### PR TITLE
ci: fix rl-wrapper call

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
     [
       "@semantic-release/exec",
       {
-        "verifyReleaseCmd": "ARTIFACT=$(npm pack --ignore-scripts | tail -1) && rl-wrapper --artifact \"$ARTIFACT\" --name wsfed --version ${nextRelease.version} --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --build-env github_actions --suppress_output",
+        "verifyReleaseCmd": "ARTIFACT=$(npm pack --ignore-scripts | tail -1) && rl-wrapper --artifact \"$ARTIFACT\" --name wsfed --version ${nextRelease.version} --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --build-env github_actions --suppress-output",
         "prepareCmd": "git diff --exit-code"
       }
     ],


### PR DESCRIPTION
### Description

Update `rl-wrapper` call to use correct supress output argument.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
